### PR TITLE
fix: don't allow players to use the entity radar

### DIFF
--- a/config/xaerominimap-common.txt
+++ b/config/xaerominimap-common.txt
@@ -1,3 +1,4 @@
 allowCaveModeOnServer:false
 allowNetherCaveModeOnServer:false
+allowRadarOnServer:false
 registerStatusEffects:false

--- a/index.toml
+++ b/index.toml
@@ -122,7 +122,7 @@ hash = "572afe2b7ca5ab18bc32f13ee92473f975fab22d62f760742d9de122284d2ea0"
 
 [[files]]
 file = "config/xaerominimap-common.txt"
-hash = "be7330bfe1a41b7cbf3578bef78e5542bccdea1110cf66adb545e564aab23193"
+hash = "9c809e5dc50075f1562ac808e092e1d7521f7679f99a525d9c0492baf74cc272"
 
 [[files]]
 file = "config/xaeroworldmap-common.txt"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "c2fc5c95241face366ea4fe78a4575b72590fff8bc0f3b90e490a4a80e6751b1"
+hash = "1f7b63845def66eb74c9b927d3a850c03cf46dc708620c359bd030d21dc0d20b"
 
 [versions]
 minecraft = "1.21.1"


### PR DESCRIPTION
Since the entity radar also shows entities living underground, it can be used to detect structures like mineshafts or strongholds.