### PR TITLE
feat: carry on

### DIFF
--- a/config/carryon-common.toml
+++ b/config/carryon-common.toml
@@ -1,0 +1,90 @@
+[settings]
+# ShutUpAnnoyingMod breaks these for performance reasons.
+# Disable them just to be sure
+heavyTiles = false
+useScripts = false
+
+# No stacking
+stackableEntities = false
+
+# We manually whitelist anything that can be picked up to prevent any
+# exploits when carrying bad blocks/entities.
+useWhitelistBlocks = true
+useWhitelistEntities = true
+pickupPlayers = false
+
+[whitelist]
+# Only add things that would actually make sense to pick up (and might
+# be difficult to move manually)
+allowedBlocks = [
+    # --- Vanilla
+    "#c:chests", # Does not include Lootr, or any of Aether's chests so people can't do silly stuff
+    "#minecraft:signs",
+    "#minecraft:hanging_signs",
+
+    "minecraft:barrel",
+    "minecraft:blast_furnace",
+    "minecraft:chiseled_bookshelf",
+    "minecraft:dispenser",
+    "minecraft:dropper",
+    "minecraft:ender_chest", 
+    "minecraft:furnace",
+    "minecraft:hopper",
+    "minecraft:smoker",
+
+    "minecraft:brewing_stand",
+    "minecraft:campfire",
+    "minecraft:cauldron",
+    "minecraft:composter",
+    "minecraft:soul_campfire",
+
+    # --- AE2
+    "ae2:drive",
+    "ae2:sky_stone_tank",
+
+    # --- Create
+    "create:basin",
+    "create:blaze_burner",
+    "create:depot",
+    "create:fluid_tank",
+    "create:item_vault",
+
+    # --- Farmers Delight
+    "#farmersdelight:cabinets",
+    "farmersdelight:basket",
+    "farmersdelight:cooking_pot",
+
+    # --- Twilight Forest
+    "twilightforest:chiseled_canopy_bookshelf"
+]
+
+allowedEntities = [
+    # --- Vanilla
+    "#c:boats",
+    "#minecraft:minecarts",
+    "minecraft:armor_stand",
+    "minecraft:bee",
+    "minecraft:cat",
+    "minecraft:chicken",
+    "minecraft:cow",
+    "minecraft:rabbit",
+    "minecraft:sheep",
+    "minecraft:snow_golem",
+    "minecraft:turtle",
+    "minecraft:wolf",
+    "minecraft:villager",
+
+    # --- Aether
+    "#aether:pigs", # Also includes Vanilla!
+    "aether:flying_cow",
+    "aether:sheepuff",
+
+    # --- Twilight Forest
+    "twilightforest:bighorn_sheep",
+    "twilightforest:deer",
+    "twilightforest:dwarf_rabbit",
+    "twilightforest:penguin",
+    "twilightforest:raven",
+    "twilightforest:squirrel",
+    "twilightforest:tiny_bird",
+]

--- a/index.toml
+++ b/index.toml
@@ -33,6 +33,10 @@ file = "config/biomesoplenty/biome_toggles.json"
 hash = "df126b719bf4cb57ae9c6199fe38ad7f1e101247267917ec06f53bc3f69a439a"
 
 [[files]]
+file = "config/carryon-common.toml"
+hash = "9fda68fd87657b0d1a2c6b0c19e43697844ae7e1a955c93117996955c15c131d"
+
+[[files]]
 file = "config/chunkloaders-common.toml"
 hash = "fc2e1e838a48c9dd354d5ff117b14327fe7683626b4804e2c15a9fa2d64471cc"
 
@@ -202,6 +206,11 @@ metafile = true
 [[files]]
 file = "mods/c2me-neoforge.pw.toml"
 hash = "b6ab381ffbe69120cb57dc359f881a8aa172b216978e46255492c9acb48d76a4"
+metafile = true
+
+[[files]]
+file = "mods/carry-on.pw.toml"
+hash = "8fde54624913d86f1176cd1086fa485f1a872573dac144347c57cab76596b715"
 metafile = true
 
 [[files]]

--- a/mods/carry-on.pw.toml
+++ b/mods/carry-on.pw.toml
@@ -1,0 +1,13 @@
+name = "Carry On"
+filename = "carryon-neoforge-1.21.1-2.2.2.11.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/joEfVgkn/versions/79dpvD0M/carryon-neoforge-1.21.1-2.2.2.11.jar"
+hash-format = "sha512"
+hash = "0a31ef680544d85c5842a54a2c61f4ead14776de69a97f36438db4076ee364cf852045d7bcd22efc269591d63fe4e2ee86bb73def795262617641b0060cb4f31"
+
+[update]
+[update.modrinth]
+mod-id = "joEfVgkn"
+version = "79dpvD0M"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "9a4bb79a1acca633e744ca551f0981199ec42b5e88789cd14ab9a47c7d82b776"
+hash = "ab787b5017bf4f1f768316a10f95cdb91ccd823f5c709293491427d343f34a0c"
 
 [versions]
 minecraft = "1.21.1"


### PR DESCRIPTION
Waow!

See https://github.com/terrarium-modpack/ShutUpAnnoyingMod/commit/2f0bddb9bd6425a42b582292fb0fea24dca137f1 for more details on the first 2 settings.

Basically, by default, it actually serializes the NBT of the block you're holding to a string every tick.
The scripting feature is kind of broken - in theory, someone with creative could abuse it (even if it's off in the config) to execute commands as console. Not good.