### PR TITLE
fix: disable ars nouveau dynamic lights

### DIFF
--- a/config/ars_nouveau-client.toml
+++ b/config/ars_nouveau-client.toml
@@ -1,7 +1,7 @@
 # This mod is trying SO HARD to be annoying
 [lights]
 showSupporterMessage = false
-lightsEnabled = true
+lightsEnabled = false
 
 [overlays]
 informLights = false # Why is this here and not in [lights] like the other annoying nag? Especially since this one *has to do with lights*. Ok bro

--- a/index.toml
+++ b/index.toml
@@ -30,7 +30,7 @@ hash = "3e0c6f3c7c02fa1a08015b944fc3a350540a256c99930a1865cca0fb91ae21c0"
 
 [[files]]
 file = "config/ars_nouveau-client.toml"
-hash = "3983badfe5910cb7229d7bf1ab141dbf1a06fe300be1ba87acb3a66a1e57f492"
+hash = "bdd8b5f02e06b62caf3276c60da571ad26b288c7dd1b6e2fc02579a385a28766"
 
 [[files]]
 file = "config/ars_nouveau-common.toml"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "c3572c956748081490bff69f7979bd560120028632cfb480401f4f2b4e10a1e0"
+hash = "600e005b7852cfc3a0aaa68c478ed528828aad7343eb69a84978c5b4d9bb028a"
 
 [versions]
 minecraft = "1.21.1"


### PR DESCRIPTION
Don't know why this was turned on.