### PR TITLE
 fix: update squatgrow config for ars nouveau

### DIFF
--- a/config/squatgrow-common.yaml
+++ b/config/squatgrow-common.yaml
@@ -7,10 +7,18 @@ hoeTakesDamage: false
 randomTickMultiplier: 4
 
 ignoreList: [
-  # Saplings
-  ## Aether
+  # --- Vanilla
+  'minecraft:acacia_sapling', 'minecraft:bamboo_sapling', 'minecraft:birch_sapling', 'minecraft:cherry_sapling',
+  'minecraft:dark_oak_sapling', 'minecraft:jungle_sapling', 'minecraft:oak_sapling', 'minecraft:spruce_sapling',
+
+  # --- Aether
   'aether:golden_oak_sapling', 'aether:potted_golden_oak_sapling', 'aether:potted_skyroot_sapling', 'aether:skyroot_sapling',
-  ## BoP
+
+  # --- Ars Nouveau
+  'ars_nouveau:blue_archwood_sapling', 'ars_nouveau:green_archwood_sapling', 'ars_nouveau:purple_archwood_sapling',
+  'ars_nouveau:red_archwood_sapling',
+
+  # --- BoP
   'biomesoplenty:cypress_sapling', 'biomesoplenty:dead_sapling', 'biomesoplenty:empyreal_sapling', 'biomesoplenty:fir_sapling',
   'biomesoplenty:flowering_oak_sapling', 'biomesoplenty:hellbark_sapling', 'biomesoplenty:jacaranda_sapling',
   'biomesoplenty:magic_sapling', 'biomesoplenty:mahogany_sapling', 'biomesoplenty:orange_maple_sapling',
@@ -18,13 +26,11 @@ ignoreList: [
   'biomesoplenty:rainbow_birch_sapling', 'biomesoplenty:red_maple_sapling', 'biomesoplenty:redwood_sapling',
   'biomesoplenty:snowblossom_sapling', 'biomesoplenty:umbran_sapling', 'biomesoplenty:willow_sapling',
   'biomesoplenty:yellow_maple_sapling',
-  ## Twilight Forest
+
+  # --- Twilight Forest
   'twilightforest:canopy_sapling', 'twilightforest:darkwood_sapling', 'twilightforest:hollow_oak_sapling',
   'twilightforest:mangrove_sapling', 'twilightforest:mining_sapling', 'twilightforest:rainbow_oak_sapling',
   'twilightforest:sorting_sapling', 'twilightforest:time_sapling', 'twilightforest:transformation_sapling',
   'twilightforest:twilight_oak_sapling',
-  ## Vanilla
-  'minecraft:acacia_sapling', 'minecraft:bamboo_sapling', 'minecraft:birch_sapling', 'minecraft:cherry_sapling',
-  'minecraft:dark_oak_sapling', 'minecraft:jungle_sapling', 'minecraft:oak_sapling', 'minecraft:spruce_sapling',
 ]
 useWhitelist: true

--- a/index.toml
+++ b/index.toml
@@ -142,7 +142,7 @@ hash = "7e8e972645572d54c255fdb878e76cfc61ca46dbbc48a3d4d30117da24ee58a9"
 
 [[files]]
 file = "config/squatgrow-common.yaml"
-hash = "c349d08d3ea0ece619091c33c344326e0b0f526e2c898fba478fb29b16c37ef9"
+hash = "62b96200f1691449eb51fbe5221273b1928b433c66e097ec6c8c4d2412a2966d"
 
 [[files]]
 file = "config/twilightforest-common.toml"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "af58990434ab0a4593d1af325bc7eeef1a289db39a0ed1f9ef0722dcfa6f7ba6"
+hash = "a770db4bddd41bdac4f0d4c52803cb3f9160962afe746b7a01786853cad62e99"
 
 [versions]
 minecraft = "1.21.1"


### PR DESCRIPTION
Originally I wanted to do Carry On stuff too but due to the way Ars Nouveau is written (badly...) it seems to override the carry on keybind on it's entities. 